### PR TITLE
Don't silently ignore duplicate key error on insert

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Provides access to a job queue
     * [.isSaturated](#markdown-header-jobqueueissaturated-boolean) : boolean
     * [.connect()](#markdown-header-jobqueueconnect)
     * [.disconnect()](#markdown-header-jobqueuedisconnect)
-    * [.push(job)](#markdown-header-jobqueuepushjob)
+    * [.push(job)](#markdown-header-jobqueuepushjob-boolean) ⇒ boolean
     * [.proxy(type, defaultOptions)](#markdown-header-jobqueueproxytype-defaultoptions-function) ⇒ function
     * [.cancel(options)](#markdown-header-jobqueuecanceloptions-job) ⇒ Job
     * [.handle(type, options, fn)](#markdown-header-jobqueuehandletype-options-fn)
@@ -183,9 +183,10 @@ Establish a connection to the database server
 ### jobQueue.disconnect()
 Disconnect from the database server
 
-### jobQueue.push(job)
+### jobQueue.push(job) ⇒ boolean
 Push a job into the job queue
 
+**Returns**: boolean - - Returns true if a new job was pushed, or false if the job already exists (based on id or unique_id)  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/lerna.json
+++ b/lerna.json
@@ -2,5 +2,5 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.10.0"
+  "version": "0.11.0"
 }

--- a/packages/oddjob-mongodb/package-lock.json
+++ b/packages/oddjob-mongodb/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjavery/oddjob-mongodb",
-  "version": "0.7.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/oddjob-mongodb/package.json
+++ b/packages/oddjob-mongodb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjavery/oddjob-mongodb",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MongoDB connector for @jjavery/oddjob",
   "keywords": [
     "oddjob",

--- a/packages/oddjob-mongodb/src/mongodb-connector.js
+++ b/packages/oddjob-mongodb/src/mongodb-connector.js
@@ -172,8 +172,8 @@ class MongodbConnector {
         { upsert: true, returnOriginal: false }
       );
     } catch (err) {
-      // Silently ignore duplicate key errors
       if (err != null && err.code === 11000) {
+        throw new Error('duplicate-key');
       } else {
         throw err;
       }

--- a/packages/oddjob-sqlite/package-lock.json
+++ b/packages/oddjob-sqlite/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjavery/oddjob-sqlite",
-  "version": "0.7.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/oddjob-sqlite/package.json
+++ b/packages/oddjob-sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjavery/oddjob-sqlite",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "SQLite connector for @jjavery/oddjob",
   "homepage": "https://github.com/jjavery/oddjob/packages/oddjob-sqlite#readme",
   "bugs": "https://github.com/jjavery/oddjob/issues",

--- a/packages/oddjob-sqlite/src/sqlite-connector.js
+++ b/packages/oddjob-sqlite/src/sqlite-connector.js
@@ -175,18 +175,14 @@ class SqliteConnector {
       job = this.createJob(job);
     }
 
-    // if (job.unique_id == null) {
-    //   delete job.unique_id;
-    // }
-
     const client = this._client;
     const jobsTableName = this._jobsTableName;
 
     try {
       await client(jobsTableName).insert(job);
     } catch (err) {
-      // Silently ignore unique constraint errors
       if (err != null && err.errno === 19) {
+        throw new Error('duplicate-key');
       } else {
         throw err;
       }
@@ -356,10 +352,6 @@ class SqliteConnector {
 
   async updateRunningJob({ id, acquired, timeout }, update) {
     await this.connected();
-
-    // if (update.unique_id == null) {
-    //   delete update.unique_id;
-    // }
 
     const query = (query) => {
       query

--- a/packages/oddjob/README.md
+++ b/packages/oddjob/README.md
@@ -126,7 +126,7 @@ Provides access to a job queue
     * [.isSaturated](#markdown-header-jobqueueissaturated-boolean) : boolean
     * [.connect()](#markdown-header-jobqueueconnect)
     * [.disconnect()](#markdown-header-jobqueuedisconnect)
-    * [.push(job)](#markdown-header-jobqueuepushjob)
+    * [.push(job)](#markdown-header-jobqueuepushjob-boolean) ⇒ boolean
     * [.proxy(type, defaultOptions)](#markdown-header-jobqueueproxytype-defaultoptions-function) ⇒ function
     * [.cancel(options)](#markdown-header-jobqueuecanceloptions-job) ⇒ Job
     * [.handle(type, options, fn)](#markdown-header-jobqueuehandletype-options-fn)
@@ -183,9 +183,10 @@ Establish a connection to the database server
 ### jobQueue.disconnect()
 Disconnect from the database server
 
-### jobQueue.push(job)
+### jobQueue.push(job) ⇒ boolean
 Push a job into the job queue
 
+**Returns**: boolean - - Returns true if a new job was pushed, or false if the job already exists (based on id or unique_id)  
 
 | Param | Type | Description |
 | --- | --- | --- |

--- a/packages/oddjob/package-lock.json
+++ b/packages/oddjob/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjavery/oddjob",
-  "version": "0.9.0",
+  "version": "0.11.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/packages/oddjob/package.json
+++ b/packages/oddjob/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jjavery/oddjob",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A job queue for Node.js applications",
   "keywords": [
     "job queue",

--- a/packages/oddjob/src/job.js
+++ b/packages/oddjob/src/job.js
@@ -314,13 +314,25 @@ class Job {
   }
 
   async _save() {
+    let saved = true;
+
     debug('Begin save job type "%s" id "%s"', this._data.type, this._data.id);
 
-    const data = await this._db.saveJob(this._data);
+    try {
+      const data = await this._db.saveJob(this._data);
 
-    this._data = data;
+      this._data = data;
+    } catch (err) {
+      if (err.message === 'duplicate-key') {
+        saved = false;
+      } else {
+        throw err;
+      }
+    }
 
     debug('End save job type "%s" id "%s"', this._data.type, this._data.id);
+
+    return saved;
   }
 
   async _complete(result) {

--- a/packages/oddjob/test/job-queue.js
+++ b/packages/oddjob/test/job-queue.js
@@ -45,8 +45,11 @@ for (let [connector, uri] of Object.entries(connectionStrings)) {
       const job2 = new Job(type, {}, { unique_id });
 
       try {
-        await jobQueue.push(job1);
-        await jobQueue.push(job2);
+        const pushed1 = await jobQueue.push(job1);
+        const pushed2 = await jobQueue.push(job2);
+
+        assert.isTrue(pushed1);
+        assert.isFalse(pushed2);
       } catch (err) {
         throw err;
       } finally {


### PR DESCRIPTION
Instead, report back via return value of JobQueue.push()